### PR TITLE
write data.dat into the em after changing m, f and rec dev

### DIFF
--- a/R/run_ss3sim.r
+++ b/R/run_ss3sim.r
@@ -133,6 +133,11 @@ run_ss3sim <- function(iterations, scenarios, m_params, f_params,
 
       # Run the operating model
       run_ss3model(scenarios = sc, iterations = i, type = "om", ...)
+    	Data = readLines(pastef(sc, i, "om", "data.ss_new"))
+		  Data.new = Data[(grep("#_expected values with no error added", Data, fixed=TRUE)+1):(grep("#_bootstrap file: 1", Data, fixed=TRUE)-1)]
+		  writeLines(Data.new, con=pastef(sc, i, "om", "data.dat"))
+
+     file.copy(from = pastef(sc, i, "om", "data.dat"), to=pastef(sc, i, "em", "data.dat"))
 
       # Survey biomass index
       with(index_params, 
@@ -146,6 +151,7 @@ run_ss3sim <- function(iterations, scenarios, m_params, f_params,
                      freq_fish       = freq_fish,
                      sd_obs_fish     = sd_obs_fish)) 
 
+ 
       # Add error in the length comp data
       SS.dat = r4ss::SS_readdat(pastef(sc, i, "em", "data.dat"))
       with(lcomp_params,


### PR DESCRIPTION
I added a few lines of code so that after running ss3 for the first time (after changing m, f, and rec dev), it takes out the ss.dat_new and extract its expected value part, and write it as data.dat
then copy
