### PR TITLE
Fix calculate_re.R for situations when column names do not match.

### DIFF
--- a/R/calculate_re.R
+++ b/R/calculate_re.R
@@ -52,10 +52,12 @@
 #' }
 calculate_re <- function(dat, add = TRUE) {
 
-  cols <- names(dat)[grep("_em", names(dat))]
-  cols <- gsub("_em", "", cols)
-  em_names <- paste0(cols, "_em")
-  om_names <- paste0(cols, "_om")
+  em_cols <- names(dat)[grep("_em", names(dat))]
+  om_cols <- names(dat)[grep("_om", names(dat))]
+  em_gsub <- gsub("_em", "", em_cols)
+  om_gsub <- gsub("_om", "", om_cols)
+  em_names <- em_cols[em_gsub %in% om_gsub]
+  om_names <- om_cols[om_gsub %in% em_gsub]
 
   re <- (dat[, em_names] - dat[, om_names]) /
     dat[, om_names]


### PR DESCRIPTION
Column names with "_om" and "_em" did not match and so subsetting
the dataframes led to a different number of dimensions for the re calc.
The script now subsets for only those parameter names that are in both
the em_cols and the om_cols rather than just copying over the names.