### PR TITLE
delete the CompReport.sso files since can be huge and not needed

### DIFF
--- a/R/ss3sim_base.r
+++ b/R/ss3sim_base.r
@@ -317,7 +317,6 @@ ss3sim_base <- function(iterations, scenarios, f_params,
                      sc, "-",i, ": is something wrong with initial model files?"))
       extract_expected_data(data_ss_new = pastef(sc, i, "om", "data.ss_new"),
                             data_out = pastef(sc, i, "em", "ss3.dat"))
-
       ## Read in the datfile once and manipulate as a list object, then
       ## write it back to file at the end, before running the EM.
       datfile <- SS_readdat(pastef(sc, i, "em", "ss3.dat"),
@@ -573,7 +572,9 @@ ss3sim_base <- function(iterations, scenarios, f_params,
       }
 
       file.remove(pastef(sc, i, fake_dat))
-
+      ## Clean up some big files that aren't necessary
+      file.remove(pastef(sc, i, "om", "CompReport.sso"))
+      file.remove(pastef(sc, i, "em", "CompReport.sso"))
       # Pause to reduce average CPUE use?
       Sys.sleep(sleep)
 


### PR DESCRIPTION
Hi all, the CompReport.sso files can be REALLY large for the conditional age-at-length data rich scenarios (75MB not uncommon). I added a couple of lines to delete these two files from the OM and EM **during** the simulation, to help save on disk space for large numbers of iterations.

As far as I can tell we can't turn the production of these files off, and we don't use them for anything. So I wouldn't mind merging this feature into the master branch. If one needs to look at a file for an individual run they can always rerun it manually.

Anyone disagree with this update?