### PR TITLE
add ESS as argument to sample comp functions

### DIFF
--- a/R/ss3sim_base.r
+++ b/R/ss3sim_base.r
@@ -348,7 +348,7 @@ ss3sim_base <- function(iterations, scenarios, f_params,
       ## Add error in the length comp data
       if(!is.null(lcomp_params$fleets)){
           lcomp_params <- add_nulls(lcomp_params,
-                     c("fleets", "Nsamp", "years", "cpar"))
+                     c("fleets", "Nsamp", "years", "cpar", "ESS"))
           dat_list <- with(lcomp_params,
                sample_lcomp(dat_list         = dat_list,
                             outfile          = NULL,
@@ -356,6 +356,7 @@ ss3sim_base <- function(iterations, scenarios, f_params,
                             Nsamp            = Nsamp,
                             years            = years,
                             cpar             = cpar,
+                            ESS              = ESS,
                             write_file       = FALSE))
       }
 
@@ -364,7 +365,7 @@ ss3sim_base <- function(iterations, scenarios, f_params,
       ## call this function we need to delete the data
       if(!is.null(agecomp_params$fleets)){
           agecomp_params <- add_nulls(agecomp_params,
-                                      c("fleets", "Nsamp", "years", "cpar"))
+                       c("fleets", "Nsamp", "years", "cpar", "ESS"))
           dat_list <- with(agecomp_params,
                           sample_agecomp(dat_list       = dat_list,
                                          outfile        = NULL,
@@ -372,6 +373,7 @@ ss3sim_base <- function(iterations, scenarios, f_params,
                                          Nsamp          = Nsamp,
                                          years          = years,
                                          cpar           = cpar,
+                                         ESS            = ESS,
                                          write_file     = FALSE))
       }
 

--- a/man-roxygen/lcomp-agecomp.R
+++ b/man-roxygen/lcomp-agecomp.R
@@ -1,3 +1,8 @@
+#' @param ESS An effective sample size to write to file (but not use in
+#' sampling). The default of NULL means to use the true (internally
+#' calculated) ESS, which is \code{Nsamp} for the multinomial case or given
+#' by the formula under \code{cpar} for the Dirichlet case. Must match the
+#' structure of the \code{years} arguments.
 #' @param cpar *A numeric value or vector the same length as
 #' \code{fleets} controlling the variance of the Dirichlet
 #' distribution used for sampling. A value of \code{1} indicates the


### PR DESCRIPTION
The ESS was previously calculated internally and not available as an argument (i.e., to misspecify sample size in the comps). I've added this option to age comps and length comps. If not specified then it reverts to the previous behavior.

This still needs to be documented but that will be done with the other updates for things like `sample_calcomp`.