### PR TITLE
Fix show.output.on.console by adding argument to run_ss3model

### DIFF
--- a/R/run_ss3model.r
+++ b/R/run_ss3model.r
@@ -49,7 +49,8 @@
 
 run_ss3model <- function(scenarios, iterations, type = c("om", "em"),
   admb_options = "", hess = FALSE, ignore.stdout =
-  TRUE, admb_pause = 0.05, ss_mode = c("safe", "optimized"), ...) {
+  TRUE, admb_pause = 0.05, ss_mode = c("safe", "optimized"),
+  show.output.on.console = FALSE, ...) {
 
   # Input checking:
   admb_options <- sanitize_admb_options(admb_options, "-nohess")
@@ -83,7 +84,7 @@ run_ss3model <- function(scenarios, iterations, type = c("om", "em"),
         setwd(pastef(sc, it, type))
         system(paste0(paste0(bin, " "), ss_em_options, admb_options),
           invisible = TRUE, ignore.stdout = ignore.stdout,
-               show.output.on.console = FALSE, ...)
+               show.output.on.console = show.output.on.console, ...)
         rename_ss3_files(path = "", ss_bin = ss_bin,
           extensions = c("par", "rep", "log", "bar"))
         setwd(wd)

--- a/man/run_ss3model.Rd
+++ b/man/run_ss3model.Rd
@@ -6,7 +6,7 @@
 \usage{
 run_ss3model(scenarios, iterations, type = c("om", "em"), admb_options = "",
   hess = FALSE, ignore.stdout = TRUE, admb_pause = 0.05,
-  ss_mode = c("safe", "optimized"), ...)
+  ss_mode = c("safe", "optimized"), show.output.on.console = FALSE, ...)
 }
 \arguments{
 \item{scenarios}{Which scenarios to run. Controls which folder contains the

--- a/man/ss3sim_base.Rd
+++ b/man/ss3sim_base.Rd
@@ -117,15 +117,13 @@ kept or deleted? \code{CompReport.sso} is often rather large and so
 deleting it can save space but the file is needed for some of the \pkg{r4ss}
 plots among other purposes.}
 
-\item{...}{Anything extra to pass to \code{\link{run_ss3model}}. For example,
-you may want to pass additional options to \code{SS3} through the argument
-\code{admb_options}. Anything that doesn't match a named argument in
-\code{\link{run_ss3model}} will be passed to the \code{\link{system}} call
-that runs \code{SS3}. If you are on a Windows computer then you might want
-to pass \code{show.output.on.console = FALSE} to make the simulations runs
-faster by not printing output to the console. Also, see the argument
-\code{ss_mode} to choose between safe or optimized SS3 executables (default
-is safe mode).}
+\item{...}{Anything extra to pass to \code{\link{run_ss3model}}. For
+example, you may want to pass additional options to \code{SS3} through
+the argument \code{admb_options}. Anything that doesn't match a named
+argument in \code{\link{run_ss3model}} will be passed to the
+\code{\link{system}} call that runs \code{SS3}.  Also, see the argument
+\code{ss_mode} to choose between safe or optimized SS3 executables
+(default is safe mode).}
 }
 \value{
 The output will appear in whatever your current \R working directory


### PR DESCRIPTION
Added argument `show.output.on.console` to `run_ss3model` but I am not sure if this is the correct function to add it to. I tested it on windows and it works, all tests work and passed checks, or at least those it was passing to begin with.