### PR TITLE
Fixbin

### DIFF
--- a/R/get_bin.R
+++ b/R/get_bin.R
@@ -18,7 +18,6 @@ get_bin <- function(bin_name = "ss3_24o_opt") {
   if (.Platform$OS.type == "windows") {
     platform <- "Windows64"
     bit <- gsub("\\/", "", Sys.getenv("R_ARCH"))
-    browser()
     if (grepl("3", bit)) {
       if (!grepl("86", bit)) {
         platform <- "Windows32"

--- a/R/get_bin.R
+++ b/R/get_bin.R
@@ -18,13 +18,15 @@ get_bin <- function(bin_name = "ss3_24o_opt") {
   if (.Platform$OS.type == "windows") {
     platform <- "Windows64"
     bit <- gsub("\\/", "", Sys.getenv("R_ARCH"))
+    browser()
     if (grepl("3", bit)) {
-      platform <- "Windows32"
-      warning("SS3 binary is not available for 32-bit ",
-        .Platform$OS.type, " within the package.\n",
-        "You must have an appropriate SS3 binary in your path.\n",
-        "See the ss3sim vignette.")
-    }
+      if (!grepl("86", bit)) {
+        platform <- "Windows32"
+        warning("SS3 binary is not available for 32-bit ",
+          .Platform$OS.type, " within the package.\n",
+          "You must have an appropriate SS3 binary in your path.\n",
+          "See the ss3sim vignette.")
+          }}
   } else {
     if (substr(R.version$os, 1, 6) == "darwin") {
       platform <- "MacOS"

--- a/R/get_bin.R
+++ b/R/get_bin.R
@@ -23,8 +23,8 @@ get_bin <- function(bin_name = "ss3_24o_opt") {
       if (!grepl("86", bit)) {
         platform <- "Windows32"
         warning("SS3 binary is not available for 32-bit ",
-          .Platform$OS.type, " within the package.\n",
-          "You must have an appropriate SS3 binary in your path.\n",
+          .Platform$OS.type, " within the package. ",
+          "You must have an appropriate SS3 binary in your path. ",
           "See the ss3sim vignette.")
           }}
   } else {
@@ -34,14 +34,14 @@ get_bin <- function(bin_name = "ss3_24o_opt") {
       if (R.version$os == "linux-gnu") {
         platform <- "Linux64"
       } else {
-        warning("SS3 binary is not available for OS", R.version$os,
-          "within the package. You must have an appropriate SS3 binary in your",
+        warning("SS3 binary is not available for OS ", R.version$os,
+          " within the package. You must have an appropriate SS3 binary in your ",
           "path. See the ss3sim vignette.")
       }
     }
   }
   loc <- system.file("bin", package = "ss3sim")
-  if (loc != "") {
+  if (loc != "") { # we found binaries in the package
     bin <- file.path(loc, platform, bin_name)
     if (!file.exists(bin)) bin <- ""
   } else {

--- a/R/get_bin.R
+++ b/R/get_bin.R
@@ -17,6 +17,7 @@ get_bin <- function(bin_name = "ss3_24o_opt") {
   # code inspiration from glmmADMB package:
   if (.Platform$OS.type == "windows") {
     platform <- "Windows64"
+    bin_name <- paste0(bin_name, ".exe")
     bit <- gsub("\\/", "", Sys.getenv("R_ARCH"))
     if (grepl("3", bit)) {
       if (!grepl("86", bit)) {
@@ -42,8 +43,7 @@ get_bin <- function(bin_name = "ss3_24o_opt") {
   loc <- system.file("bin", package = "ss3sim")
   if (loc != "") {
     bin <- file.path(loc, platform, bin_name)
-    bintest <- c(bin, paste0(bin, ".exe"))
-    if (all(!file.exists(bintest))) bin <- ""
+    if (!file.exists(bin)) bin <- ""
   } else {
     bin <- ""
   }

--- a/R/get_bin.R
+++ b/R/get_bin.R
@@ -20,7 +20,7 @@ get_bin <- function(bin_name = "ss3_24o_opt") {
     bit <- gsub("\\/", "", Sys.getenv("R_ARCH"))
     if (grepl("3", bit)) {
       platform <- "Windows32"
-      warning("SS3 binary is not available for 32-bit ", 
+      warning("SS3 binary is not available for 32-bit ",
         .Platform$OS.type, " within the package.\n",
         "You must have an appropriate SS3 binary in your path.\n",
         "See the ss3sim vignette.")
@@ -41,7 +41,8 @@ get_bin <- function(bin_name = "ss3_24o_opt") {
   loc <- system.file("bin", package = "ss3sim")
   if (loc != "") {
     bin <- file.path(loc, platform, bin_name)
-    if (!file.exists(bin)) bin <- ""
+    bintest <- c(bin, paste0(bin, ".exe"))
+    if (all(!file.exists(bintest))) bin <- ""
   } else {
     bin <- ""
   }


### PR DESCRIPTION
@seananderson Can you check to see the fixes I made are logical? A new user was having problems on a windows machine, and was not able to use ss3sim because get_bin() was saying the files did not exist because the files are stored as .exe files on windows computers which resulted in FALSE, hence the reason for the paste0 call. Then when I tried to test things on another windows I was getting an error because it thought it was a 32 bit machine when really it was not. I think I fixed both issues.