### PR TITLE
Add SS linux 3.30.15.03, build old, current, and dev versions of R on travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
 
 language: R
+r:
+  - oldrel
+  - release
+  - devel
 sudo: required
 cache: packages
 dist: xenial


### PR DESCRIPTION
Note that ss3sim tests are failing with R>=4.0.0 on the development branch @kellijohnson-NOAA and I are trying to figure out why. In the meantime, it may be safest to stick with R 3.6.2 or lower. We have added the 3 builds to assist with debugging this issue.

This linux exe also replaces an invalid one currently on the development branch.