### PR TITLE
Small fixes for functions called by get_results all

### DIFF
--- a/R/get-results.r
+++ b/R/get-results.r
@@ -337,7 +337,7 @@ get_results_mod <- function(dir = getwd(), is_EM = NULL, is_OM = NULL) {
     forecastTF <- FALSE
   }
   report <- SS_output(file.path(dir), covar = FALSE, verbose = FALSE,
-                      forecast = forecastTF, warn = FALSE,
+                      compfile = NULL, forecast = forecastTF, warn = FALSE,
                       readwt = FALSE, printstats = FALSE, NoCompOK = TRUE,
                       ncols = NULL)
   ## Get dfs

--- a/R/get-results.r
+++ b/R/get-results.r
@@ -176,8 +176,11 @@ get_results_scenario <- function(scenario, directory = getwd(),
     ## especially in case of an error
     old_wd <- getwd()
     on.exit(setwd(old_wd))
-    if (file.exists(file.path(directory, scenario))) {
-        setwd(file.path(directory, scenario))
+    if(file.exists(normalizePath(directory))) {
+        setwd(directory)
+    }
+    if (file.exists(file.path(scenario))) {
+        setwd(file.path(scenario))
     } else {
         stop(paste("Scenario", scenario, "does not exist in", directory))
     }

--- a/R/get-results.r
+++ b/R/get-results.r
@@ -10,7 +10,6 @@
 #' @author Merrill Rudd
 #' @export
 id_scenarios <- function(directory) {
-  all.dirs <- list.dirs(path = directory, full.names = FALSE, recursive = FALSE)
   all.dirs <- list.dirs(path = directory, full.names = FALSE, recursive = TRUE)
   seperator <- paste0(.Platform$file.sep, "[0-9]+", .Platform$file.sep)
   scensfull <- grep(seperator, all.dirs, value = TRUE)

--- a/R/get-results.r
+++ b/R/get-results.r
@@ -1,22 +1,24 @@
-#' Identify ss3sim scenarios within a directory
+#' Identify scenarios in \code{directory}
 #'
-#' @param directory The directory which contains scenario folders with
-#'    results.
-#' @return A character vector of folders
+#' Find folders within \code{directory} that contain iterations,
+#' i.e., "1", "2", "3", ..., and thus, allowing for unique scenario names.
+#' @param directory The directory that you want to search for scenarios.
+#'   The search is recursive, and thus, it is in one's best interest to
+#'   provide a shorter path name rather than one high up in the call stack.
+#' @return A character vector of relative paths to directories that contain
+#'   iterations.
 #' @author Merrill Rudd
 #' @export
 id_scenarios <- function(directory) {
-    ## Get unique scenarios that exist in the folder. Might be other random
-    ## stuff in the folder so be careful to extract only scenario folders.
-    all.dirs <- list.dirs(path = directory, full.names = FALSE, recursive = FALSE)
-    temp.dirs <- sapply(seq_along(all.dirs), function(i) {
-        x <- unlist(strsplit(all.dirs[i], split = "/"))
-        return(x[length(x)])
-    })
-    scens <- temp.dirs#[grepl("^([A-Z]{1}[0-9]+-)+[a-z-]+$", temp.dirs)]
-    if (length(scens) == 0) warning(paste("No scenario folders found in",
-             directory))
-    else return(scens)
+  all.dirs <- list.dirs(path = directory, full.names = FALSE, recursive = FALSE)
+  all.dirs <- list.dirs(path = directory, full.names = FALSE, recursive = TRUE)
+  seperator <- paste0(.Platform$file.sep, "[0-9]+", .Platform$file.sep)
+  scensfull <- grep(seperator, all.dirs, value = TRUE)
+  scens <- unique(sapply(strsplit(scensfull, seperator), "[[", 1))
+  if (length(scens) == 0) {
+    stop("No scenario folders were found in ", directory)
+  }
+  return(scens)
 }
 
 #' Extract SS3 simulation output

--- a/R/get-results.r
+++ b/R/get-results.r
@@ -13,7 +13,7 @@ id_scenarios <- function(directory) {
         x <- unlist(strsplit(all.dirs[i], split = "/"))
         return(x[length(x)])
     })
-    scens <- temp.dirs[grepl("^([A-Z]{1}[0-9]+-)+[a-z-]+$", temp.dirs)]
+    scens <- temp.dirs#[grepl("^([A-Z]{1}[0-9]+-)+[a-z-]+$", temp.dirs)]
     if (length(scens) == 0) warning(paste("No scenario folders found in",
              directory))
     else return(scens)

--- a/R/get-results.r
+++ b/R/get-results.r
@@ -176,7 +176,7 @@ get_results_scenario <- function(scenario, directory = getwd(),
     ## especially in case of an error
     old_wd <- getwd()
     on.exit(setwd(old_wd))
-    if(file.exists(normalizePath(directory))) {
+    if(file.exists(normalizePath(directory, mustWork = FALSE))) {
         setwd(directory)
     }
     if (file.exists(file.path(scenario))) {

--- a/R/get-results.r
+++ b/R/get-results.r
@@ -337,7 +337,7 @@ get_results_mod <- function(dir = getwd(), is_EM = NULL, is_OM = NULL) {
     forecastTF <- FALSE
   }
   report <- SS_output(file.path(dir), covar = FALSE, verbose = FALSE,
-                      compfile = "none", forecast = forecastTF, warn = FALSE,
+                      forecast = forecastTF, warn = FALSE,
                       readwt = FALSE, printstats = FALSE, NoCompOK = TRUE,
                       ncols = NULL)
   ## Get dfs

--- a/tests/testthat/test-get-results.R
+++ b/tests/testthat/test-get-results.R
@@ -17,6 +17,12 @@ dir.create(file.path("scenario", "1", "em"), recursive = TRUE)
 ignore <- file.copy(dir(simple, full.names = TRUE), file.path("scenario", "1", "om"))
 ignore <- file.copy(dir(simple, full.names = TRUE), file.path("scenario", "1", "em"))
 
+test_that("id_scenarios() finds correct folder", {
+  expect_true(id_scenarios(getwd()) == "scenario")
+  expect_true(basename(id_scenarios("..")) == "scenario")
+  expect_error(id_scenarios("test"))
+})
+
 test_that("get_results_iter() works", {
   res <- get_results_iter(file.path("scenario", "1"))
   expect_length(res, 3)

--- a/tests/testthat/test-get-results.R
+++ b/tests/testthat/test-get-results.R
@@ -9,7 +9,6 @@ on.exit(unlink(temp_path, recursive = TRUE), add = TRUE)
 d <- system.file("extdata", package = "ss3sim")
 om <- file.path(d, "models", "cod-om")
 em <- file.path(d, "models", "cod-em")
-case_folder <- file.path(d, "eg-cases")
 simple <- tail(dir(system.file("extdata", package = "r4ss"),
   full.names = TRUE), 1)
 


### PR DESCRIPTION
I discovered in SSMSE that [relative directories didn't work](https://github.com/nmfs-fish-tools/SSMSE/issues/21). I also discovered while fixing this issue that the names of a scenario were restrictive (assumed of the form like cod-E0-F1-M0, as created when using casefiles). I pushed a fix (commit 16325cf5) to eliminate filtering for directory names altogether (so all folders are assumed to contain a scenario's files, if not specified), but maybe some other fix should be made?