### PR TITLE
feat: allow different filenames for summary csvs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,5 +49,5 @@ Imports:
     stats,
     utils
 Remotes: github::r4ss/r4ss@development
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ss3sim
 Type: Package
 Title: Fisheries Stock Assessment Simulation Testing with Stock Synthesis
-Version: 1.1.0
+Version: 1.1.1
 Authors@R: c(person(c("Kelli", "F."), "Johnson", 
     email = "kelli.johnson@noaa.gov",
     role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# ss3sim 1.1.1
+
+* Allow for custom name of results files
+
 # ss3sim 1.1.0
 
 * Upgrade to SS 3.30.15.03

--- a/R/get-results.r
+++ b/R/get-results.r
@@ -38,7 +38,9 @@ id_scenarios <- function(directory) {
 #'   \code{directory}.
 #' @param type A character string specifying if you want the results to be
 #'   written to the disk and returned as a long or wide data frame, where the
-#'   default is \code{"long"}.
+#'   default is \code{"long"}
+#' @param filename_prefix A character string specifying a prefix to append to
+#'   the filename. Defaults to "ss3sim".
 #' @export
 #' @return Returns a list of 3 dataframes: scalar, ts, and dq.
 #' Creates two .csv files in the current working directory:
@@ -46,7 +48,7 @@ id_scenarios <- function(directory) {
 #' @author Cole Monnahan, Merrill Rudd
 #' @family get-results
 get_results_all <- function(directory = getwd(), overwrite_files = FALSE,
-  user_scenarios = NULL, type = c("long", "wide")) {
+  user_scenarios = NULL, type = c("long", "wide"), filename_prefix = "ss3sim") {
 
     old_wd <- getwd()
     on.exit(setwd(old_wd))
@@ -109,23 +111,25 @@ get_results_all <- function(directory = getwd(), overwrite_files = FALSE,
     ts.all <- convert_to_wide(ts.all)
     dq.all <- convert_to_wide(dq.all)
   }
-  if (file.exists("ss3sim_scalar.csv")) {
-    if (overwrite_files) write.csv(scalar.all, file = "ss3sim_scalar.csv", row.names = FALSE)
+  scalar_filename <- paste0(filename_prefix, "_scalar.csv")
+  ts_filename <- paste0(filename_prefix, "_ts.csv")
+  if (file.exists(scalar_filename)) {
+    if (overwrite_files) write.csv(scalar.all, file = scalar_filename, row.names = FALSE)
     else {
-      warning("ss3sim_scalar.csv already exists and overwrite_files = FALSE, ",
+      warning(scalar_filename, " already exists and overwrite_files = FALSE, ",
                  "so a new file was not written")
     }
   } else { # can write either way
-    write.csv(scalar.all, file = "ss3sim_scalar.csv", row.names = FALSE)
+    write.csv(scalar.all, file = scalar_filename, row.names = FALSE)
   }
-  if (file.exists("ss3sim_ts.csv")) {
-    if (overwrite_files) write.csv(ts.all, file = "ss3sim_ts.csv", row.names = FALSE)
+  if (file.exists(ts_filename)) {
+    if (overwrite_files) write.csv(ts.all, file = ts_filename, row.names = FALSE)
     else {
-      warning("ss3sim_ts.csv already exists and overwrite_files = FALSE, ",
+      warning(ts_filename, " already exists and overwrite_files = FALSE, ",
               "so a new file was not written")
     }
   } else { # can write either way
-    write.csv(ts.all, file = "ss3sim_ts.csv", row.names = FALSE)
+    write.csv(ts.all, file = ts_filename, row.names = FALSE)
   }
 ret <- list(scalar = scalar.all,
                   ts = ts.all,

--- a/R/get-results.r
+++ b/R/get-results.r
@@ -43,9 +43,11 @@ id_scenarios <- function(directory) {
 #'   the filename. Defaults to "ss3sim".
 #' @export
 #' @return Returns a list of 3 dataframes: scalar, ts, and dq.
-#' Creates two .csv files in the current working directory:
+#' Creates two .csv files in the current working directory,
+#' where the names of those files are based on \code{filename_prefix}
+#' and the default leads to the following:
 #' \code{ss3sim_ts.csv} and \code{ss3sim_scalar.csv}.
-#' @author Cole Monnahan, Merrill Rudd
+#' @author Cole Monnahan, Merrill Rudd, Kathryn Doering
 #' @family get-results
 get_results_all <- function(directory = getwd(), overwrite_files = FALSE,
   user_scenarios = NULL, type = c("long", "wide"), filename_prefix = "ss3sim") {

--- a/R/get-results.r
+++ b/R/get-results.r
@@ -113,25 +113,25 @@ get_results_all <- function(directory = getwd(), overwrite_files = FALSE,
     ts.all <- convert_to_wide(ts.all)
     dq.all <- convert_to_wide(dq.all)
   }
-  scalar_filename <- paste0(filename_prefix, "_scalar.csv")
-  ts_filename <- paste0(filename_prefix, "_ts.csv")
-  if (file.exists(scalar_filename)) {
-    if (overwrite_files) write.csv(scalar.all, file = scalar_filename, row.names = FALSE)
+  scalar.file.all <- paste0(filename_prefix, "_scalar.csv")
+  ts.file.all <- paste0(filename_prefix, "_ts.csv")
+  if (file.exists(scalar.file.all)) {
+    if (overwrite_files) write.csv(scalar.all, file = scalar.file.all, row.names = FALSE)
     else {
-      warning(scalar_filename, " already exists and overwrite_files = FALSE, ",
+      warning(scalar.file.all, " already exists and overwrite_files = FALSE, ",
                  "so a new file was not written")
     }
   } else { # can write either way
-    write.csv(scalar.all, file = scalar_filename, row.names = FALSE)
+    write.csv(scalar.all, file = scalar.file.all, row.names = FALSE)
   }
-  if (file.exists(ts_filename)) {
-    if (overwrite_files) write.csv(ts.all, file = ts_filename, row.names = FALSE)
+  if (file.exists(ts.file.all)) {
+    if (overwrite_files) write.csv(ts.all, file = ts.file.all, row.names = FALSE)
     else {
-      warning(ts_filename, " already exists and overwrite_files = FALSE, ",
+      warning(ts.file.all, " already exists and overwrite_files = FALSE, ",
               "so a new file was not written")
     }
   } else { # can write either way
-    write.csv(ts.all, file = ts_filename, row.names = FALSE)
+    write.csv(ts.all, file = ts.file.all, row.names = FALSE)
   }
 ret <- list(scalar = scalar.all,
                   ts = ts.all,

--- a/R/get-results.r
+++ b/R/get-results.r
@@ -115,21 +115,15 @@ get_results_all <- function(directory = getwd(), overwrite_files = FALSE,
   }
   scalar.file.all <- paste0(filename_prefix, "_scalar.csv")
   ts.file.all <- paste0(filename_prefix, "_ts.csv")
-  if (file.exists(scalar.file.all)) {
-    if (overwrite_files) write.csv(scalar.all, file = scalar.file.all, row.names = FALSE)
-    else {
-      warning(scalar.file.all, " already exists and overwrite_files = FALSE, ",
-                 "so a new file was not written")
-    }
+  if (file.exists(scalar.file.all) & !overwrite_files) {
+    warning(scalar.file.all, " already exists and overwrite_files = FALSE, ",
+      "so a new file was not written.")
   } else { # can write either way
     write.csv(scalar.all, file = scalar.file.all, row.names = FALSE)
   }
-  if (file.exists(ts.file.all)) {
-    if (overwrite_files) write.csv(ts.all, file = ts.file.all, row.names = FALSE)
-    else {
-      warning(ts.file.all, " already exists and overwrite_files = FALSE, ",
-              "so a new file was not written")
-    }
+  if (file.exists(ts.file.all) & !overwrite_files) {
+    warning(ts.file.all, " already exists and overwrite_files = FALSE, ",
+      "so a new file was not written.")
   } else { # can write either way
     write.csv(ts.all, file = ts.file.all, row.names = FALSE)
   }

--- a/man/get_results_all.Rd
+++ b/man/get_results_all.Rd
@@ -8,7 +8,8 @@ get_results_all(
   directory = getwd(),
   overwrite_files = FALSE,
   user_scenarios = NULL,
-  type = c("long", "wide")
+  type = c("long", "wide"),
+  filename_prefix = "ss3sim"
 )
 }
 \arguments{
@@ -24,11 +25,16 @@ in. Default is \code{NULL}, which indicates find all scenario folders in
 
 \item{type}{A character string specifying if you want the results to be
 written to the disk and returned as a long or wide data frame, where the
-default is \code{"long"}.}
+default is \code{"long"}}
+
+\item{filename_prefix}{A character string specifying a prefix to append to
+the filename. Defaults to "ss3sim".}
 }
 \value{
 Returns a list of 3 dataframes: scalar, ts, and dq.
-Creates two .csv files in the current working directory:
+Creates two .csv files in the current working directory,
+where the names of those files are based on \code{filename_prefix}
+and the default leads to the following:
 \code{ss3sim_ts.csv} and \code{ss3sim_scalar.csv}.
 }
 \description{
@@ -47,6 +53,6 @@ Other get-results:
 \code{\link{get_results_timeseries}()}
 }
 \author{
-Cole Monnahan, Merrill Rudd
+Cole Monnahan, Merrill Rudd, Kathryn Doering
 }
 \concept{get-results}


### PR DESCRIPTION
Default value is the same as previously, but now has more flexibility. @kellijohnson, feel free to make changes if you would prefer this done another way. Also, I did not yet run `devtools::document()`