### PR TITLE
Fixes and refactoring to improve ss3sim when using a simdf

### DIFF
--- a/R/change_em_binning.r
+++ b/R/change_em_binning.r
@@ -13,7 +13,7 @@
 #'   \code{ss3.dat} file.
 #' @param lbin_method A numeric value of either \code{NULL, 1, 2, 3} to change
 #'   the lbin_method for the population bin. Only supports either \code{NULL, 1,
-#'   2} at the moment. \code{NULL} means to keep it unchanged.
+#'   2} at the moment. \code{NULL} means to not rebin.
 #' @param pop_binwidth Population length bin width. Only necessary for
 #' \code{lbin_method=2}. Note that this value must be smaller than the bin
 #' width specified in length composition data \code{len_bins} or SS3 will
@@ -80,7 +80,8 @@ change_em_binning <- function(dat_list, outfile = NULL, bin_vector, lbin_method 
                               pop_maximum_size=NULL) {
   ## If lbin_method is NULL then don't do anything
   if (is.null(lbin_method)){
-    return(NULL)
+    warning("lbin_method must be supplied for em rebinning to run. Skipping rebinning.")
+    return(dat_list)
   }
   # error checking
   if (!is.numeric(bin_vector)) {

--- a/R/copy_ss3models.r
+++ b/R/copy_ss3models.r
@@ -43,7 +43,7 @@ copy_ss3models <- function(model_dir, scenarios,
         stop("The value passed to the argument type must be either om or em.")
     for(sc in scenarios) {
         for(it in iterations) {
-            from <- model_dir
+            from <- normalizePath(model_dir, mustWork = TRUE)
             to <- file.path(sc, it)
             dir.create(to, showWarnings = FALSE, recursive = TRUE)
             if(file.exists(file.path(to, type))){

--- a/R/copy_ss3models.r
+++ b/R/copy_ss3models.r
@@ -43,7 +43,7 @@ copy_ss3models <- function(model_dir, scenarios,
         stop("The value passed to the argument type must be either om or em.")
     for(sc in scenarios) {
         for(it in iterations) {
-            from <- file.path(model_dir)
+            from <- model_dir
             to <- file.path(sc, it)
             dir.create(to, showWarnings = FALSE, recursive = TRUE)
             if(file.exists(file.path(to, type))){
@@ -51,7 +51,7 @@ copy_ss3models <- function(model_dir, scenarios,
                 iteration_exists <- TRUE
             } else {
                 file.copy(from, to, recursive = TRUE)
-                orig_model_folder <- rev(strsplit(from, "/")[[1]])[1]
+                orig_model_folder <- basename(from)
                 file.rename(file.path(to, orig_model_folder), file.path(to, type))
                 ## sanity check and rename for consistency:
                 verify_input(model_dir = file.path(to, type), type = type)

--- a/R/get_ss_version.R
+++ b/R/get_ss_version.R
@@ -4,14 +4,12 @@
 #'   originally read in using \code{\link[r4ss]{SS_readdat}}.
 #' @template dat_list
 get_ss_ver_dl <- function(dat_list){
-  if(exists("SSversion", where = dat_list)){
-    version <- dat_list$SSversion
-  } else if(exists("ReadVersion", where = dat_list)){
-    version <- dat_list$ReadVersion
-  } else {
-    stop("SS datafile version not found.") # Change to be more informative?
+  version <- dat_list[["SSversion"]]
+  if(is.null(version)) {
+    version <- dat_list[["ReadVersion"]]
   }
-  return(version)
+  if(is.null(version)) stop("SS datafile version not found")
+  version
 }
 
 #' Get the ss version (either 3.24 or 3.30) from an ss file

--- a/R/run_ss3sim.r
+++ b/R/run_ss3sim.r
@@ -147,6 +147,11 @@ run_ss3sim <- function(iterations, simdf = NULL,
         weight_comps_params = w)
     })
   } else {
+    if(!is.null(om_dir) | !is.null(em_dir)) {
+      stop("The variables om_dir and em_dir should be passed as columns ",
+      "within the simdf, not as separate argument. Please specify om_dir and/or",
+      "em_dir within simdf and leave om_dir and em_dir as arguments NULL.")
+    }
     arg_list <- setup_scenarios(simdf)
   }
   # Note that inside a foreach loop you pop out of your current

--- a/R/run_ss3sim.r
+++ b/R/run_ss3sim.r
@@ -186,6 +186,6 @@ run_ss3sim <- function(iterations, simdf = NULL,
   }
 
   message("Completed iterations: ", paste(iterations, collapse = ", "),
-    " for scenarios: ", paste(scenarios, collapse = ", "))
+    " for scenarios: ", paste(unlist(ignore), collapse = ", "))
   return(unlist(ignore))
 }

--- a/R/setup_scenarios.R
+++ b/R/setup_scenarios.R
@@ -49,7 +49,7 @@ setup_scenarios_fillmissing <- function(dataframe) {
                                                         colnames(musthavecols),
                                                         duplicates.ok = FALSE))]
   missingcols <- !colnames(musthavecols) %in% present_cols
-  dataframe <- cbind(musthavecols[, missingcols], dataframe)
+  dataframe <- cbind(musthavecols[, missingcols, drop = FALSE], dataframe)
   return(dataframe)
 }
 

--- a/R/setup_scenarios.R
+++ b/R/setup_scenarios.R
@@ -38,10 +38,10 @@ setup_scenarios <- function(input = NULL) {
 #' @return A data frame with potentially more columns than what was provided.
 setup_scenarios_fillmissing <- function(dataframe) {
   musthavecols <- data.frame(
-    om = system.file("extdata", "models", "cod-om", package = "ss3sim"),
+    om_dir = system.file("extdata", "models", "cod-om", package = "ss3sim"),
     # todo: make this NULL such that the EM is created from the OM internally
     # within ss3sim, e.g., in the run_ss3sim function
-    em = system.file("extdata", "models", "cod-em", package = "ss3sim"),
+    em_dir = system.file("extdata", "models", "cod-em", package = "ss3sim"),
     stringsAsFactors = FALSE
   )
 

--- a/R/setup_scenarios.R
+++ b/R/setup_scenarios.R
@@ -44,8 +44,11 @@ setup_scenarios_fillmissing <- function(dataframe) {
     em_dir = system.file("extdata", "models", "cod-em", package = "ss3sim"),
     stringsAsFactors = FALSE
   )
-
-  missingcols <- !colnames(musthavecols) %in% colnames(dataframe)
+  # use pmatch to allow partial matching in the dataframe
+  present_cols <- colnames(musthavecols)[na.omit(pmatch(colnames(dataframe),
+                                                        colnames(musthavecols),
+                                                        duplicates.ok = FALSE))]
+  missingcols <- !colnames(musthavecols) %in% present_cols
   dataframe <- cbind(musthavecols[, missingcols], dataframe)
   return(dataframe)
 }

--- a/R/ss3sim_base.r
+++ b/R/ss3sim_base.r
@@ -393,13 +393,12 @@ ss3sim_base <- function(iterations, scenarios, f_params,
       }
 
 	    ## Now change the binning structure in the EM ss3.dat file as needed
-      if (!is.null(em_binning_params$lbin_method)) {
+      if (!is.null(em_binning_params)) {
           dat_list <- do.call("change_em_binning", c(
               dat_list         = list(dat_list),
               outfile          = NULL,
               em_binning_params))
       }
-
       # Manipulate EM control file to adjust what gets estimated
 
       if(!is.null(estim_params)) {

--- a/tests/testthat/test-change-e.R
+++ b/tests/testthat/test-change-e.R
@@ -184,11 +184,6 @@ test_that("change_em_binning exits on error with cond. age at length", {
 })
 
 
-test_that("change_EM_binning returns NULL if lbin method is NULL", {
- expect_null(change_em_binning(dat_list = datalist, bin_vector = 2:10,
-                               lbin_method = NULL))
-})
-
 test_that("change_EM_binning stops on error when expected", {
   expect_error(change_em_binning(dat_list = datalist, bin_vector = c("a", "b"),
                                  lbin_method = 1),


### PR DESCRIPTION
Addresses #285 and some other small issues.
Includes: 
- Fixes to improve parsing user input to run_ss3sim. Note that if using a simdf, the em_dir and om_dir should be defined within the simdf rather than using the separate variable inputs to run_ss3sim.
- refactor function call for change_em_binning within ss3sim to improve code clarity
-refactor the get_ss_version function, which wasn't working