### PR TITLE
Issue 286

### DIFF
--- a/R/change_em_binning.r
+++ b/R/change_em_binning.r
@@ -205,8 +205,6 @@ change_em_binning <- function(dat_list, outfile = NULL, bin_vector, lbin_method 
   # Re-bin conditional age-at-length comps (not implemented)
   # if all Lbin_lo == -1 then there aren't any CAL data:
   if (length(unique(dat_list$agecomp$Lbin_lo)) > 1) {
-    stop("There is conditional age at length data. Currently, rebinning",
-         "does not work when there is conditional age at length data.")
     if (!identical(dat_list$Lbin_method, 3)) {
       stop("Lbin_method was not set to 3 in the SS3 data file. ",
            "change_em_binning() requires the data file to specify conditional ",
@@ -241,9 +239,7 @@ change_em_binning <- function(dat_list, outfile = NULL, bin_vector, lbin_method 
     lookup <- data.frame(
       Lbin_lo = old_binvector,
       lbin_new_low = bin_vector[findInterval(old_binvector, bin_vector)],
-      lbin_new_high =
-        c(bin_vector, -1)[findInterval(old_binvector,
-          bin_vector)+1])
+      lbin_new_high = bin_vector[findInterval(old_binvector, bin_vector)])
 
     # the re-binning happens here:
     new_cal <- merge(old_cal, lookup, by = "Lbin_lo", all = FALSE, sort = FALSE)

--- a/tests/testthat/test-change-e.R
+++ b/tests/testthat/test-change-e.R
@@ -158,29 +158,29 @@ test_that("change_em_binning works with method = 2", {
   expect_equal(ncol(output$lencomp)-6, length(new_bin_vec))
 })
 
-test_that("change_em_binning exits on error with cond. age at length", {
+test_that("change_em_binning works with cond. age at length", {
   # a valid bin vector when there is CAL must only include values that are in
   # the population bins, supposedly.
   #I think this test is broken and needs to be fixed.
- pop_bin_input <- 2
- pop_min_size_input <- min(datalist$lbin_vector_pop) + 1
- pop_max_size_input <- max(datalist$lbin_vector_pop) - 1
- new_bin_vec <- seq(min(datalist$lbin_vector),
-                    max(datalist$lbin_vector),
-                    by = 3*2)
  datalist_CAL <- datalist
+ pop_bin_input <- 2
+ pop_min_size_input <- min(datalist$lbin_vector_pop)
+ pop_max_size_input <- max(datalist$lbin_vector_pop)
+ new_bin_vec <- c(20, 50, 152)
  # change approximately half of the obs to CAL
  a_col <- nrow(datalist_CAL$agecomp)
- max_change <- as.integer(a_col/2)
- datalist_CAL$agecomp$Lbin_lo[1:max_change] <- new_bin_vec[2]
- datalist_CAL$agecomp$Lbin_hi[1:max_change] <- new_bin_vec[length(new_bin_vec)-2]
- expect_error(change_em_binning(dat_list = datalist_CAL,
+ max_change <- 20
+ datalist_CAL$agecomp$Lbin_lo[1:max_change] <- rep(datalist_CAL$lbin_vector, length.out = max_change)
+ datalist_CAL$agecomp$Lbin_hi[1:max_change] <- rep(datalist_CAL$lbin_vector, length.out = max_change)
+ new_dat <- change_em_binning(dat_list = datalist_CAL,
                                 bin_vector = new_bin_vec,
                                 lbin_method = 2,
                                 pop_binwidth = pop_bin_input,
                                 pop_minimum_size = pop_min_size_input,
-                                pop_maximum_size = pop_max_size_input),
-              "There is conditional age at length data")
+                                pop_maximum_size = pop_max_size_input)
+ new_cal <- new_dat[["agecomp"]][new_dat$agecomp$Lbin_lo != -1, ]
+ old_cal <- datalist_CAL[["agecomp"]][datalist_CAL$agecomp$Lbin_lo != -1, ]
+ expect_true(all(new_cal$Lbin_lo %in% c(-1, new_bin_vec)))
 })
 
 


### PR DESCRIPTION
This pull request address #286  and allows rebinning to be used with conditional age at length data. Most of the code was already there, but a few small changes were made:
- removed the stop message preventing rebinning with CAAL data
- Changed the lbin hi values to be the same as lbin lo. I think this is the correct way to only be using a single bin for the data (for instance, using 11 and 11 as the low and high bin, when the next bin is 15 followed by 19, is correct, categorizing the data as from 11-14.9999, while using 11 and 15  would actually categorize the data as coming from between 11 - 18.999.
- modified a test for using rebinning with CAAL data.