### PR TITLE
fix, test: get get_results_all() working with models not complete

### DIFF
--- a/R/get-results.r
+++ b/R/get-results.r
@@ -71,7 +71,7 @@ get_results_all <- function(directory = getwd(), overwrite_files = FALSE,
   if (length(scenarios) == 0) {
     stop("No scenarios found in:", directory)
   }
-  message("Extracting results from ", length(scenarios), "scenarios")
+  message("Extracting results from ", length(scenarios), " scenarios")
 
   ## Loop through each scenario in folder in serial
   dq.list <- ts.list <- scalar.list <-

--- a/R/get-results.r
+++ b/R/get-results.r
@@ -71,7 +71,7 @@ get_results_all <- function(directory = getwd(), overwrite_files = FALSE,
   if (length(scenarios) == 0) {
     stop("No scenarios found in:", directory)
   }
-  message("Extracting results from", length(scenarios), "scenarios")
+  message("Extracting results from ", length(scenarios), "scenarios")
 
   ## Loop through each scenario in folder in serial
   dq.list <- ts.list <- scalar.list <-
@@ -326,8 +326,12 @@ get_results_mod <- function(dir = getwd(), is_EM = NULL, is_OM = NULL) {
   # Input checks:
   if (!file.exists(file.path(dir, "Report.sso")) |
     file.size(file.path(dir, "Report.sso")) == 0) {
-    message("Missing Report.sso file for: ", dir, "; skipping...")
-    return(NA)
+    results_mod <- list(
+      scalar = NA,
+      timeseries = NA,
+      derived = NA
+    )
+    return(results_mod)
   }
   # figure out if is EM and if forecast report should be read
   if (is.null(is_EM)) {
@@ -645,6 +649,15 @@ get_compfit <- function(report.file, name) {
 #' @return A dataframe
 make_df <- function(list_name, list_df) {
   list_df_comp <- lapply(list_df, function(x) x[[list_name]])
+  # set anything not a dataframe (the NA values) as Null
+  list_df_comp <- lapply(list_df_comp, function (x) {
+      if(!is.data.frame(x)) {
+        x <- NULL
+      }
+      x
+    })
+  # drop any empty elements
+  list_df_comp <- purrr::compact(list_df_comp)
   all_nms <- unique(unlist(lapply(list_df_comp, names)))
   # this extra code is needed in case of extra colnames that are not in both
   # dataframes.

--- a/tests/testthat/test-get-results.R
+++ b/tests/testthat/test-get-results.R
@@ -118,3 +118,23 @@ test_that("get_results_scenario() does overwrite files if overwrite_files = TRUE
   ss3sim_scalar <- read.csv(file.path("scenario", "results_scalar_scenario.csv")) # should be real data
   expect_true(ncol(ss3sim_scalar) > 1)
 })
+
+test_that("get_results_all() works when some report files missing", {
+# get rid of old csv files
+all_files <- list.files(recursive = TRUE)
+to_rm <- grep("csv$", all_files, value = TRUE)
+file.remove(to_rm)
+# get rid ofreport files for the EMS
+file.remove("scenario/1/em/Report.sso")
+file.remove("scenario/1/em_2/Report.sso")
+# if in doubt, double check the commented out line returns "scenario/1/om/Report.sso"
+# ONLY.
+# grep("/Report\\.sso$", list.files(recursive = TRUE), value = TRUE)
+return <- get_results_all(user_scenarios = "scenario")
+expect_length(unique(return$scalar$model_run), 1)
+expect_true(unique(return$scalar$model_run) == "om")
+expect_true(unique(return$ts$model_run) == "om")
+expect_length(unique(return$ts$model_run), 1)
+expect_true(unique(return$dq$model_run) == "om")
+expect_length(unique(return$dq$model_run), 1)
+})

--- a/tests/testthat/test-get-results.R
+++ b/tests/testthat/test-get-results.R
@@ -138,3 +138,76 @@ expect_length(unique(return$ts$model_run), 1)
 expect_true(unique(return$dq$model_run) == "om")
 expect_length(unique(return$dq$model_run), 1)
 })
+
+test_that("get_results_all() works when all report files missing for 1 scenario", {
+  # get rid of old csv files
+  all_files <- list.files(recursive = TRUE)
+  to_rm <- grep("csv$", all_files, value = TRUE)
+  file.remove(to_rm)
+  dir.create("scenario_2")
+  file.copy(from = list.dirs("scenario", recursive = FALSE), to = "scenario_2", recursive = TRUE)
+  file.remove("scenario_2/1/om/Report.sso")
+  # if in doubt, double check the commented out line returns "scenario/1/om/Report.sso"
+  # ONLY.
+  # grep("/Report\\.sso$", list.files(recursive = TRUE), value = TRUE)
+  return <- get_results_all(user_scenarios = c("scenario_2", "scenario"))
+  expect_type(return, "list")
+  expect_length(return, 3)
+  expect_true(all(return$ts$scenario == "scenario"))
+  expect_true(all(return$scalar$scenario == "scenario"))
+  expect_true(all(return$dq$scenario == "scenario"))
+})
+
+test_that("get_results_all() works when 1 iteration of report files missing", {
+  # get rid of old csv files
+  all_files <- list.files(recursive = TRUE)
+  to_rm <- grep("csv$", all_files, value = TRUE)
+  file.remove(to_rm)
+  dir.create("scenario/2")
+  file.copy(from = list.files("scenario/1", recursive = F, include.dirs = T, full.names = T), to = "scenario/2", recursive = T)
+  # get rid ofreport files for the EMS
+  file.remove("scenario/1/om/Report.sso")
+  # if in doubt, double check the commented out line returns "scenario/1/om/Report.sso"
+  # ONLY.
+  # grep("/Report\\.sso$", list.files(recursive = TRUE), value = TRUE)
+  return <- get_results_all(user_scenarios = "scenario")
+  expect_type(return, "list")
+  expect_length(return, 3)
+  expect_true(all(return$ts$iteration == "2"))
+  expect_true(all(return$scalar$iteration == "2"))
+  expect_true(all(return$dq$iteration == "2"))
+})
+
+test_that("get_results_all() works when all report files missing", {
+  # get rid of old csv files
+  all_files <- list.files(recursive = TRUE)
+  to_rm <- grep("csv$", all_files, value = TRUE)
+  file.remove(to_rm)
+  # get rid ofreport files for the EMS
+  file.remove("scenario/2/om/Report.sso")
+  # if in doubt, double check the commented out line returns "scenario/1/om/Report.sso"
+  # ONLY.
+  # grep("/Report\\.sso$", list.files(recursive = TRUE), value = TRUE)
+  return <- get_results_all(user_scenarios = "scenario")
+  expect_type(return, "list")
+  expect_length(return, 3)
+  expect_true(is.null(return$ts))
+  expect_true(is.null(return$scalar))
+  expect_true(is.null(return$dq))
+})
+
+test_that("get_results_all() works when all report files missing for 2 scenarios", {
+  # get rid of old csv files
+  all_files <- list.files(recursive = TRUE)
+  to_rm <- grep("csv$", all_files, value = TRUE)
+  file.remove(to_rm)
+  # if in doubt, double check the commented out line returns "scenario/1/om/Report.sso"
+  # ONLY.
+  # grep("/Report\\.sso$", list.files(recursive = TRUE), value = TRUE)
+  return <- get_results_all(user_scenarios = c("scenario_2", "scenario"))
+  expect_type(return, "list")
+  expect_length(return, 3)
+  expect_true(is.null(return$ts))
+  expect_true(is.null(return$scalar))
+  expect_true(is.null(return$dq))
+})


### PR DESCRIPTION
This was needed for SSMSE, where sometimes EM model files may be copied but not run. Some logic was causing get_results_all() to error when this was the case.

This PR also adds a test to make sure functions work when some Report files are missing.

Thanks @rwildermuth for reporting this issue that was causing the SSMSE::SSMSE_summarize_all() function to not work in some cases (also tagging you for awareness)

@kellijohnson-NOAA , let me know if it looks ok or not when you have a chance