### PR TITLE
change path in gha files

### DIFF
--- a/.github/workflows/call-doc-and-style-r.yml
+++ b/.github/workflows/call-doc-and-style-r.yml
@@ -9,4 +9,4 @@ on:
 name: call-doc-and-style-r
 jobs:
   call-workflow:
-    uses: nmfs-stock-synthesis/workflows/.github/workflows/doc-and-style-r.yml@main
+    uses: nmfs-fish-tools/ghactions4r/.github/workflows/doc-and-style-r.yml@main

--- a/.github/workflows/call-r-cmd-check.yml
+++ b/.github/workflows/call-r-cmd-check.yml
@@ -14,4 +14,4 @@ on:
 name: call-r-cmd-check
 jobs:
   call-workflow:
-    uses: nmfs-stock-synthesis/workflows/.github/workflows/r-cmd-check.yml@main
+    uses: nmfs-fish-tools/ghactions4r/.github/workflows/r-cmd-check.yml@main

--- a/.github/workflows/call-style.yml
+++ b/.github/workflows/call-style.yml
@@ -4,4 +4,4 @@ on:
 name: call-style
 jobs:
   call-workflow:
-    uses: nmfs-stock-synthesis/workflows/.github/workflows/style-r-code.yml@main
+    uses: nmfs-fish-tools/ghactions4r/.github/workflows/style-r-code.yml@main

--- a/.github/workflows/call-update-docs.yml
+++ b/.github/workflows/call-update-docs.yml
@@ -4,4 +4,4 @@ on:
 name: call-update-docs
 jobs:
   call-workflow:
-    uses: nmfs-stock-synthesis/workflows/.github/workflows/update-roxygen-docs.yml@main
+    uses: nmfs-fish-tools/ghactions4r/.github/workflows/update-roxygen-docs.yml@main

--- a/.github/workflows/call-update-pkgdown.yml
+++ b/.github/workflows/call-update-pkgdown.yml
@@ -7,4 +7,4 @@ on:
 name: call-update-pkgdown
 jobs:
   call-workflow:
-    uses: nmfs-stock-synthesis/workflows/.github/workflows/update-pkgdown.yml@main
+    uses: nmfs-fish-tools/ghactions4r/.github/workflows/update-pkgdown.yml@main


### PR DESCRIPTION
reusable workflows are now in [nmfs-fish-tools/ghactions4r repo](https://github.com/nmfs-fish-tools/ghactions4r) 