### PR TITLE
Fix typo in `standardize_sampling_args()`

### DIFF
--- a/R/case-parsing.r
+++ b/R/case-parsing.r
@@ -48,7 +48,7 @@ standardize_sampling_args <- function(fleets,
   if (length(years) == 1 & length(fleets) > 1) {
     years <- rep(years, length(fleets))
   }
-  if (length(other_input) == 1 & length(fleets > 1)) {
+  if (length(other_input) == 1 & length(fleets) > 1) {
     other_input <- rep(other_input, length(fleets))
   }
   # make sure other_inputs has the same length vectors as the number of years


### PR DESCRIPTION
While debugging some errors in my code, I noticed that I think this is a typo. It was completely unrelated to my bug (which was entirely of my own doing), but seemed worth fixing.