### PR TITLE
Adds area to `get_results_timeseries()` for SSmse

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: ss3sim
 Title: Fisheries Stock Assessment Simulation Testing with Stock Synthesis
-Version: 1.20.2
+Version: 1.21.0
 Authors@R: c(
     person(c("Kelli", "F."), "Johnson", , "kelli.johnson@noaa.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-5149-451X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # News
 
+## ss3sim 1.21.0
+
+* Added season to the time series results and stopped hard-coding to
+  season 1.
+* Added month to the time series results.
+* Use better semantic versioning protocols where the minor number
+  is reserved for features and the patch number (terminal) is for
+  fixes.
+
 ## ss3sim 1.20.2
 
 * Fixed bug in Introduction vignette regarding self-test estimation method to

--- a/R/get-results.r
+++ b/R/get-results.r
@@ -403,10 +403,8 @@ get_results_timeseries <- function(report.file) {
   other_cols <- which(colnames(report.file$timeseries) %in%
     c("Yr", "Seas", "Bio_smry", "SpawnBio", "Recruit_0"))
   xx <- report.file$timeseries[, c(other_cols, catch_cols, dead_cols, F_cols)]
-  # remove parentheses from column names because they make the names
-  # non-synatic
-  colnames(xx) <- gsub("\\(|\\)", "", colnames(xx))
-  colnames(xx) <- gsub("\\:", "", colnames(xx))
+  # remove parentheses and colons from column names
+  colnames(xx) <- gsub("\\(|\\)|\\:", "", colnames(xx))
   xx <- xx[xx$Yr %in% years, ]
   # Get SPR from derived_quants
   spr <- report.file$derived_quants[grep(

--- a/man/get_results_timeseries.Rd
+++ b/man/get_results_timeseries.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/get-results.r
 \name{get_results_timeseries}
 \alias{get_results_timeseries}
-\title{Extract time series from a model run.}
+\title{Return the time series information from an iteration}
 \usage{
 get_results_timeseries(report.file)
 }
@@ -10,9 +10,37 @@ get_results_timeseries(report.file)
 \item{report.file}{An \code{\link[r4ss]{SS_output}} list for a model
 (operating model or estimation model).}
 }
+\value{
+A data frame with the following columns:
+\itemize{
+\item year
+\item Area
+\item Seas
+\item Bio_smry
+\item SpawnBio
+\item Recruit_0
+\item retainB_\link{0-9}+
+\item retainN_\link{0-9}+
+\item deadB_\link{0-9}+
+\item deadN_\link{0-9}+
+\item F_\link{0-9}+
+\item SPRratio
+\item rec_dev
+\item raw_rec_dev
+}
+}
 \description{
-Extract time series from an \code{\link[r4ss:SS_output]{r4ss::SS_output()}} list from a model run.
-Returns a data.frame of the results for SSB, recruitment and effort by year.
+Extract and return time series from an \code{\link[r4ss:SS_output]{r4ss::SS_output()}} list, that is
+read in from the estimation method of a single iteration. The main time
+series information is included but no information about the uncertainty of
+those measurements is available. See the derived quantities for uncertainty.
+}
+\details{
+Information about both season and area are included in the data frame. For
+values that have no associated season or area, i.e., are summary values over
+all areas and seasons, the values are repeated for each area/season
+combination within a given year. For example, the recruitment deviation is
+for all areas and is thus repeated in each row across areas for a given year.
 }
 \seealso{
 Other get-results: 


### PR DESCRIPTION
I am so excited that the user community wants to add area-specific models to the mix! So, thank you @skylersagarese-NOAA for reaching out. Hopefully this change fixes the lack of area in the time series results for you. Given the slightly complicated workflow here, you will need to install this branch of ss3sim and then run your code for SSmse as we talked. The branch is locally passing the tests but there are 4 warnings related to things that I need to update and do not pertain, or at least I do not think that they pertain, to the code changes for this request. Again, thanks for reaching out and let me know how your testing goes. You can also test the function locally by just installing this branch and running
```
output_list <- r4ss::SS_output("YourDirectoryWithModelFilesHere", verbose = FALSE, printstats = FALSE)
small_test <- ss3sim::get_results_timeseries(output_list)
head(small_test)
```
Once you approve @skylersagarese-NOAA, then I will assign @k-doering-NOAA as a reviewer.