### PR TITLE
remove ghactions4r workflows

### DIFF
--- a/.github/workflows/call-style.yml
+++ b/.github/workflows/call-style.yml
@@ -1,7 +1,0 @@
-# use styler to style code
-on:
-  workflow_dispatch:
-name: call-style
-jobs:
-  call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/style-r-code.yml@main

--- a/.github/workflows/call-update-docs.yml
+++ b/.github/workflows/call-update-docs.yml
@@ -1,7 +1,0 @@
-# Run devtools::document()
-on:
-  workflow_dispatch:
-name: call-update-docs
-jobs:
-  call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/update-roxygen-docs.yml@main


### PR DESCRIPTION
Will be deprecated by https://github.com/nmfs-fish-tools/ghactions4r/pull/131.