### PR TITLE
Vignette advice for data weighting

### DIFF
--- a/R/create_em.R
+++ b/R/create_em.R
@@ -71,8 +71,8 @@ create_em <- function(dir_in = system.file("extdata", "models", "cod-om", packag
   )
   dat_list <- inputs[["dat"]]
   ctl_list <- inputs[["ctl"]]
-  ctl_list$MainRdevYrFirst <- dat_list$Nages
-  ctl_list$recdev_early_start <- floor(dat_list$Nages * -0.5)
+  ctl_list$MainRdevYrFirst <- dat_list$styr + dat_list$Nages
+  ctl_list$recdev_early_start <- dat_list$styr + floor(dat_list$Nages * -0.5)
   ctl_list$recdev_early_phase <- abs(ctl_list$recdev_early_phase)
   ctl_list$recdev_phase <- abs(ctl_list$recdev_phase)
   ctl_list$last_early_yr_nobias_adj <- ifelse(

--- a/vignettes/making-models.Rmd
+++ b/vignettes/making-models.Rmd
@@ -176,8 +176,7 @@ the model writes the new input files.
     and a negative phase value,
     e.g., `1 1 1 0 0.01 -1`.
 
-1. Remove non-terminator lines in `# Input variance adjustments factors` or
-   set all elements in the  `Value` column to `0`.
+1. Remove non-terminator lines in `# Input variance adjustments factors`.
    For example, your file could look like the following:
    ```
    # Input variance adjustments factors: 


### PR DESCRIPTION
The vignette on constructing new models states that [data weights should either be set to zero, or the table should be empty](https://github.com/ss3sim/ss3sim/blob/202b590337f631ad1b21b24cd025deec45847733/vignettes/making-models.Rmd#L195-L197). I used the former approach, and then ran `create_em()` followed by `run_ss3sim()`, and the model was not converging because all of the adjusted samples sizes for the composition data were zero. Using an empty table worked, so I suggest only recommending that.

I am running SS3 V3.30.22.1 for Windows.

I am not entirely clear why the commit from 9/27/24 is showing up here, as that was merged in.