### PR TITLE
Update DESCRIPTION - r4ss dependency version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,6 +49,7 @@ Imports:
     magrittr,
     purrr,
     r4ss (>= 1.46.1),
+    r4ss (<= 1.49.3),
     rlang,
     stats,
     stringi,


### PR DESCRIPTION
Placed an upper bound on the r4ss dependency to address column name mismatch with r4ss ver 1.50.0 [(Issue 428)](https://github.com/ss3sim/ss3sim/issues/428)

